### PR TITLE
Fall back to default values for ratelimit settings

### DIFF
--- a/fpush-ratelimit/src/config.rs
+++ b/fpush-ratelimit/src/config.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use std::time::Duration;
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", default)]
 pub struct RatelimitSettings {
     #[serde(deserialize_with = "serde_humantime")]
     pub hard_ratelimit_time: Duration,


### PR DESCRIPTION
Use default values for [ratelimit][1] configuration options that weren't specified.

[1]: https://github.com/monal-im/fpush#ratelimit