### PR TITLE
Dockerfile: Add Dockerfile and respective workflow

### DIFF
--- a/.github/workflows/ctr.yml
+++ b/.github/workflows/ctr.yml
@@ -1,0 +1,66 @@
+name: Build & publish fpush ctr image
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ github.repository }}
+
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/Dockerfile
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Log in to ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      ## currently not pushing the image to the github registry.
+
+      # - name: Build & push image
+      #   uses: docker/build-push-action@v3
+      #   if: github.event_name == 'push'
+      #   with:
+      #     context: .
+      #     file: docker/Dockerfile
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     platforms: linux/amd64
+      #     push: true
+      #     tags: ${{ steps.meta.outputs.tags }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+### alternative tag is e.g. '1.72.0'
+ARG RUST_VSN='stable'
+
+##### Build
+FROM docker.io/clux/muslrust:${RUST_VSN} as builder
+
+COPY / ./
+RUN cargo build --release
+
+RUN mkdir -p /rootfs/etc/fpush \
+ && mv $(find target/ -name fpush -type f -executable) /rootfs/fpush \
+ && touch /rootfs/etc/fpush/settings.json
+
+##### Runtime
+FROM gcr.io/distroless/static-debian12:nonroot AS prod
+
+COPY --from=builder /rootfs /
+
+ENV RUST_LOG=info
+
+ENTRYPOINT ["/fpush","/etc/fpush/settings.json"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,24 @@
+# Dockerfile for fpush
+
+This folder holds an example Dockerfile.
+
+To build the image, run the following command from the root of this repository:
+
+```bash
+docker build -t localhost/fpush:latest -f docker/Dockerfile .
+```
+
+Run the image with:
+
+```bash
+docker run --init -d \
+    --name fpush \
+    -v /path/to/settings.json:/etc/fpush/settings.json \
+    -v /path/to/apple.p12:/path/to/apple.p12 \
+    -v /path/to/google.json:/path/to/google.json \
+    -e RUST_LOG=info \
+    localhost/fpush:latest
+```
+
+Note: Apple's p12 and/or Google's json file need to be mounted into the
+container as you can see in the example above.


### PR DESCRIPTION
Follow up from @weiss communication to you.

The workflow only builds the image without publishing it to the github registry `monal-im/fpush`.

If you want to publish them, just uncomment the last step in the respective workflow file. This will build and push an image based on the latest commit from this repository.

If you want a different name for the subdir, just let me know.

Cheers,
Saarko

P.S. The Dockerfile builds fpush with statically linked musl-libc packaged into [google distroless images](https://github.com/GoogleContainerTools/distroless) to have the smallest image possible as well as following best practices in terms of attack surface, running unprivileged, etc.