### PR TITLE
Log error message when error is thrown in apns initialization

### DIFF
--- a/fpush-apns/src/push.rs
+++ b/fpush-apns/src/push.rs
@@ -39,7 +39,10 @@ impl FpushApns {
                 Ok(wrapped_conn)
             }
             Err(a2::error::Error::ReadError(_)) => Err(PushError::PushEndpointPersistent),
-            Err(_) => Err(PushError::PushEndpointTmp),
+            Err(e) => {
+                error!("Problem initializing apple config: {}", e);
+                Err(PushError::PushEndpointTmp)
+            },
         }
     }
 }


### PR DESCRIPTION
# TL; DR

This was swallowing errors from the `a2` crate that would have been helpful to see. This PR adds logging to surface a more useful error message.

# Background

I was attempting to setup `fpush` and got the following error on startup:
```
thread 'main' panicked at /home/ubuntu/fpush/fpush-push/src/lib.rs:64:91:
called `Result::unwrap()` on an `Err` value: PushErrors(PushEndpointTmp)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The error wasn't particularly descriptive, so I traced it to the `fpush-apns` package and added the logging in this PR.

After adding the logging this is what surfaced:
```
Error creating a signature: error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../crypto/evp/evp_fetch.c:349:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
```

For anyone who gets this error: I exported my push certificate from Keychain Access in macOS as a `p12` file. What seems to be happening is that Keychain Access is encrypting the private key with an outdated algorithm and OpenSSL in the `a2` crate is choking on it because that algorithm isn't loaded by default. I couldn't figure out a way to load the `legacy` provider in `fpush` so what I ended up doing was using the `openssl` cli tool to export the key to `pem` format using the `-legacy` flag, then convert it back to `p12`. Hope this helps someone not bash their head against a wall for 3 hours like I did.