### PR TITLE
Dockerfile: Fix base image to include SSL certificates not shipped by scratch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,43 @@
-### alternative tag is e.g. '1.72.0'
-ARG RUST_VSN='stable'
+ARG RUST_VSN='1.78'
 
 ##### Build
-FROM docker.io/clux/muslrust:${RUST_VSN} as builder
+FROM cgr.dev/chainguard/wolfi-base as builder
+ARG RUST_VSN
 
+RUN apk -U upgrade && apk add --no-cache \
+        build-base \
+        openssl-dev \
+        pax-utils \
+        rust-$RUST_VSN
+
+WORKDIR /fpush
 COPY / ./
 RUN cargo build --release
 
 RUN mkdir -p /rootfs/etc/fpush \
  && mv $(find target/ -name fpush -type f -executable) /rootfs/fpush \
- && touch /rootfs/etc/fpush/settings.json
+ && touch /rootfs/etc/fpush/settings.json \
+ && scanelf --needed --nobanner --format '%n#p' --recursive "$PWD" \
+    | tr ',' '\n' \
+    | sort -u \
+    | awk 'system("[ -e $PWD" $1 " ]") == 0 { next } { print "so:" $1 }' \
+        > /rootfs/runDeps
 
 ##### Runtime
-FROM gcr.io/distroless/static-debian12:nonroot AS prod
-
+FROM cgr.dev/chainguard/wolfi-base AS release
 COPY --from=builder /rootfs /
 
-ENV RUST_LOG=info
+RUN apk -U upgrade && apk add --no-cache \
+        $(cat /runDeps) \
+        tini \
+ && apk del --repositories-file /dev/null \
+        apk-tools \
+        busybox \
+        wolfi-base \
+        wolfi-keys \
+        zlib
 
-ENTRYPOINT ["/fpush","/etc/fpush/settings.json"]
+ENV RUST_LOG="info"
+
+ENTRYPOINT ["/sbin/tini","--"]
+CMD ["/fpush","/etc/fpush/settings.json"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,3 +22,15 @@ docker run --init -d \
 
 Note: Apple's p12 and/or Google's json file need to be mounted into the
 container as you can see in the example above.
+
+Additionally, Apple's p12 file may comes with outdated cipher suites 
+which are only support by the OpenSSL legacy provider from version `3.3.3`
+on. To make such a p12 file compatibile, you can use the following commands:
+
+```shell
+$ openssl pkcs12 -legacy -in apple-old.p12 -nodes -out p12-decrypted.tmp
+(enter passphrases if prompted)
+$ openssl pkcs12 -in p12-decrypted.tmp -export -out apple-new.p12
+(enter passphrases if prompted)
+$ rm p12-decrypted.tmp
+```


### PR DESCRIPTION
Follow up PR for the first Dockerfile. 

- Building Fpush based on [Wolfi/OS](https://github.com/wolfi-dev/os) instead of Alpine linux to use `glibc` instead of `musl-libc`
- Add `tini` signal handling helper to improve container environment integration, e.g. `Kubernetes`
- Update Docker Readme to include a hint about legacy ciphers used by Apple P12 files (this may be better located in the main README.md file)

Motivation:
- Musl-libc may have some issues with Rust
- Potentially improving the performance by switching to glibc linked binaries (not yes statistically evaluated, but too many positive examples exist, e.g. processone/ejabberd, istio/ztunnel, etc.)

The corresponding Docker image is used in a production environment. 

NB: I opened the PR right away due to its simple nature, but feel free to provide any feedback, concerns etc. 👍 